### PR TITLE
Remove logging of pem-common path

### DIFF
--- a/bin/pem
+++ b/bin/pem
@@ -28,7 +28,6 @@ main() {
     [ -z "$CMD" ] && usage && exit 1
     [ "$CMD" = "commands" ] && commands && exit 0
     [ ! -e "$PEM_DIR/pem-$CMD" ] && usage && exit 2
-    echo "$PEM_DIR/pem-common"
     . "$PEM_DIR/pem-common"
     . "$PEM_DIR/pem-$CMD"
     pem-default "$@"


### PR DESCRIPTION
Echo of pem directory name in main() method was removed to disable this output in command line.
#18 