### PR TITLE
Add documentation to 'folder-env'

### DIFF
--- a/bin/pem-folder-env
+++ b/bin/pem-folder-env
@@ -23,3 +23,7 @@ pem-default() {
     ln -s `pyenv which python | sed -e 's/\/bin\/python//g'` ${PEM_VENV_LINK} && \
     echo "'$PWD/${PEM_VENV_LINK}' link is created to local Python folder."
 }
+
+usage() {
+    echo "Usage: pem folder-env"
+}


### PR DESCRIPTION
Implement `usage` function which displays 'folder-env' documentation.

Affects #31